### PR TITLE
[FIX] Enable test_overload unit test

### DIFF
--- a/test/test_overload.py
+++ b/test/test_overload.py
@@ -9,15 +9,13 @@ def test_overload():
     mat = SparseTensor(row=row, col=col)
 
     other = paddle.to_tensor([1, 2, 3]).view([3, 1])
-    # TODO: temporary skip this case. More details: https://github.com/PaddlePaddle/Paddle/pull/73119
-    # other + mat
+    other + mat
     mat + other
-    # other * mat
+    other * mat
     mat * other
 
     other = paddle.to_tensor([1, 2, 3]).view([1, 3])
-    # TODO: temporary skip this case. More details: https://github.com/PaddlePaddle/Paddle/pull/73119
-    # other + mat
+    other + mat
     mat + other
-    # other * mat
+    other * mat
     mat * other


### PR DESCRIPTION
Reason: Paddle support `__radd__` and `__rmul__` now. 

More details: https://github.com/PaddlePaddle/Paddle/pull/73119.