### PR TITLE
fix: rename 'cuda_version' to 'sparse_cuda_version'

### DIFF
--- a/csrc/version.cpp
+++ b/csrc/version.cpp
@@ -11,7 +11,7 @@
 #include "macros.h"
 
 
-SPARSE_API std::vector<paddle::Tensor> cuda_version() {
+SPARSE_API std::vector<paddle::Tensor> sparse_cuda_version() {
   auto cpu_place = paddle::CPUPlace();
 #ifdef WITH_CUDA
   int64_t version = CUDA_VERSION;
@@ -22,19 +22,19 @@ SPARSE_API std::vector<paddle::Tensor> cuda_version() {
 }
 
 
-std::vector<paddle::DataType> cuda_version_infer_dtype() {
+std::vector<paddle::DataType> sparse_cuda_version_infer_dtype() {
   return {paddle::DataType::INT64};
 }
 
 
-std::vector<std::vector<int64_t>> cuda_version_infer_shape(int64_t M) {
+std::vector<std::vector<int64_t>> sparse_cuda_version_infer_shape(int64_t M) {
   return {{1}};
 }
 
 
-PD_BUILD_OP(cuda_version)
+PD_BUILD_OP(sparse_cuda_version)
     .Inputs({})
     .Outputs({"out"})
-    .SetKernelFn(PD_KERNEL(cuda_version))
-    .SetInferShapeFn(PD_INFER_SHAPE(cuda_version_infer_shape))
-    .SetInferDtypeFn(PD_INFER_DTYPE(cuda_version_infer_dtype));
+    .SetKernelFn(PD_KERNEL(sparse_cuda_version))
+    .SetInferShapeFn(PD_INFER_SHAPE(sparse_cuda_version_infer_shape))
+    .SetInferDtypeFn(PD_INFER_DTYPE(sparse_cuda_version_infer_dtype));

--- a/paddle_sparse/__init__.py
+++ b/paddle_sparse/__init__.py
@@ -14,7 +14,7 @@ except ImportError:
     )
 
 
-cuda_version = paddle_sparse_ops.cuda_version().item()
+cuda_version = paddle_sparse_ops.sparse_cuda_version().item()
 if paddle.version.cuda_version is not None and cuda_version != -1:  # pragma: no cover
     if cuda_version < 10000:
         major, minor = int(str(cuda_version)[0]), int(str(cuda_version)[2])


### PR DESCRIPTION
对 “cuda_version” 算子（op）的名称进行修改，规避在不同库中出现同名 “cuda_version” 算子的情况，从而解决在同一运行环境下无法同时使用这些库的问题。

